### PR TITLE
fix: retry push on non-fast-forward when the remote branch moved

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -112,20 +112,51 @@ impl Repo {
         Ok(())
     }
 
-    pub fn push(
-        &self,
-        GitConfig {
+    pub fn push(&self, config: GitConfig) -> Result<bool> {
+        // cepler records state onto a branch that is frequently written by other
+        // CI jobs (and humans). Between our fetch and our push another commit can
+        // land on the remote branch, which turns our push into a non-fast-forward
+        // that libgit2 rejects with `ErrorCode::NotFastForward`. Rather than
+        // failing the whole deploy, re-fetch, re-rebase our state commit onto the
+        // new tip and try again a bounded number of times.
+        const MAX_PUSH_ATTEMPTS: usize = 5;
+        let GitConfig {
             branch,
             private_key,
             ..
-        }: GitConfig,
-    ) -> Result<bool> {
-        let callbacks = remote_callbacks(private_key.clone());
+        } = config;
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match self.try_push(&branch, &private_key) {
+                Ok(pushed) => return Ok(pushed),
+                Err(e) => {
+                    let non_fast_forward = e
+                        .downcast_ref::<git2::Error>()
+                        .map(|git_err| git_err.code() == git2::ErrorCode::NotFastForward)
+                        .unwrap_or(false);
+                    if non_fast_forward && attempt < MAX_PUSH_ATTEMPTS {
+                        eprintln!(
+                            "Push rejected because the remote moved; re-fetching and retrying ({}/{})",
+                            attempt, MAX_PUSH_ATTEMPTS
+                        );
+                        std::thread::sleep(std::time::Duration::from_millis(200 * attempt as u64));
+                        continue;
+                    }
+                    return Err(e).context("Couldn't push to remote");
+                }
+            }
+        }
+    }
+
+    fn try_push(&self, branch: &str, private_key: &str) -> Result<bool> {
+        let callbacks = remote_callbacks(private_key.to_string());
         let mut fo = git2::FetchOptions::new();
         fo.remote_callbacks(callbacks);
         let mut remote = self.inner.find_remote("origin")?;
         remote
-            .fetch(&[branch.clone()], Some(&mut fo), None)
+            .fetch(&[branch], Some(&mut fo), None)
             .context("Couldn't fetch origin")?;
 
         let annotated_head = self
@@ -133,12 +164,12 @@ impl Repo {
             .reference_to_annotated_commit(&self.inner.head()?)
             .context("Couldn't find head reference")?;
 
-        let head_commit = match self.inner.find_branch(&branch, BranchType::Local) {
-            Ok(branch) if branch.is_head() => annotated_head,
+        let head_commit = match self.inner.find_branch(branch, BranchType::Local) {
+            Ok(local) if local.is_head() => annotated_head,
             _ => {
                 let branch_ref = self
                     .inner
-                    .branch_from_annotated_commit(&branch, &annotated_head, true)
+                    .branch_from_annotated_commit(branch, &annotated_head, true)
                     .context("Could not create local branch")?;
                 self.inner.reference_to_annotated_commit(branch_ref.get())?
             }
@@ -180,17 +211,16 @@ impl Repo {
 
         if n_applied > 0 {
             let mut push_options = PushOptions::new();
-            push_options.remote_callbacks(remote_callbacks(private_key));
-            remote
-                .push(
-                    &[format!(
-                        "{}:{}",
-                        head_commit.refname().unwrap(),
-                        head_commit.refname().unwrap(),
-                    )],
-                    Some(&mut push_options),
-                )
-                .context("Couldn't push to remote")?;
+            push_options.remote_callbacks(remote_callbacks(private_key.to_string()));
+            let refname = head_commit
+                .refname()
+                .context("Annotated commit has no reference name")?;
+            // NOTE: intentionally not wrapped with `.context(..)` so the caller can
+            // downcast the raw git2 error and detect `NotFastForward` to retry.
+            remote.push(
+                &[format!("{}:{}", refname, refname)],
+                Some(&mut push_options),
+            )?;
             Ok(true)
         } else {
             Ok(false)
@@ -512,4 +542,113 @@ fn remote_callbacks(key: String) -> RemoteCallbacks<'static> {
         Cred::ssh_key_from_memory(username_from_url.unwrap(), None, &key, None)
     });
     callbacks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git2::Repository;
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        dir.push(format!(
+            "cepler-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn stage_and_commit(repo: &Repository, msg: &str) -> Oid {
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let sig = Signature::now("Test", "test@example.com").unwrap();
+        let parents: Vec<Commit> = repo
+            .head()
+            .ok()
+            .and_then(|h| h.peel_to_commit().ok())
+            .into_iter()
+            .collect();
+        let parent_refs: Vec<&Commit> = parents.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parent_refs)
+            .unwrap()
+    }
+
+    fn push_branch(repo: &Repository, branch: &str) {
+        let mut remote = repo.find_remote("origin").unwrap();
+        remote
+            .push(&[format!("refs/heads/{0}:refs/heads/{0}", branch)], None)
+            .unwrap();
+    }
+
+    // Reproduces the production scenario where a concurrent writer advances the
+    // state branch before cepler pushes: cepler must rebase its state commit onto
+    // the new remote tip and push successfully instead of erroring out with a
+    // non-fast-forward. Exercises the full fetch -> rebase -> push machinery that
+    // `push`'s retry loop depends on.
+    #[test]
+    fn push_rebases_state_commit_onto_concurrent_remote_commit() {
+        let base = unique_tmp_dir("push");
+        let bare_path = base.join("remote.git");
+        let work_a = base.join("work_a");
+        let work_b = base.join("work_b");
+        let bare_url = bare_path.to_str().unwrap().to_string();
+
+        // Bare remote + worker A seeded with an initial commit on the default branch.
+        Repository::init_bare(&bare_path).unwrap();
+        let repo_a = Repository::init(&work_a).unwrap();
+        repo_a.remote("origin", &bare_url).unwrap();
+        std::fs::write(work_a.join("file.txt"), "v1").unwrap();
+        stage_and_commit(&repo_a, "initial commit");
+        let branch = repo_a.head().unwrap().shorthand().unwrap().to_string();
+        push_branch(&repo_a, &branch);
+
+        // A second worker advances the remote branch with an unrelated commit.
+        let repo_b = Repository::clone(&bare_url, &work_b).unwrap();
+        std::fs::write(work_b.join("other.txt"), "concurrent").unwrap();
+        let concurrent = stage_and_commit(&repo_b, "concurrent writer commit");
+        push_branch(&repo_b, &branch);
+
+        // Worker A (still pointing at the old tip) records new state and pushes.
+        std::fs::write(work_a.join("state.txt"), "cepler state").unwrap();
+        stage_and_commit(&repo_a, "ci(cepler): Updated state");
+
+        let repo = Repo {
+            inner: repo_a,
+            gate: None,
+        };
+        let config = GitConfig {
+            url: bare_url.clone(),
+            branch: branch.clone(),
+            gates_branch: None,
+            private_key: String::new(),
+            dir: work_a.to_str().unwrap().to_string(),
+        };
+
+        let pushed = repo.push(config).expect("push should succeed after rebase");
+        assert!(pushed, "expected the state commit to be pushed");
+
+        // The remote tip must now contain BOTH the concurrent commit and our state,
+        // with the state commit rebased directly on top of the concurrent commit.
+        let verify = Repository::clone(&bare_url, base.join("verify")).unwrap();
+        let tip = verify.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(tip.summary().unwrap(), "ci(cepler): Updated state");
+        assert_eq!(
+            tip.parent(0).unwrap().id(),
+            concurrent,
+            "state commit must be rebased onto the concurrent commit"
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -113,12 +113,6 @@ impl Repo {
     }
 
     pub fn push(&self, config: GitConfig) -> Result<bool> {
-        // cepler records state onto a branch that is frequently written by other
-        // CI jobs (and humans). Between our fetch and our push another commit can
-        // land on the remote branch, which turns our push into a non-fast-forward
-        // that libgit2 rejects with `ErrorCode::NotFastForward`. Rather than
-        // failing the whole deploy, re-fetch, re-rebase our state commit onto the
-        // new tip and try again a bounded number of times.
         const MAX_PUSH_ATTEMPTS: usize = 5;
         let GitConfig {
             branch,
@@ -215,8 +209,6 @@ impl Repo {
             let refname = head_commit
                 .refname()
                 .context("Annotated commit has no reference name")?;
-            // NOTE: intentionally not wrapped with `.context(..)` so the caller can
-            // downcast the raw git2 error and detect `NotFastForward` to retry.
             remote.push(
                 &[format!("{}:{}", refname, refname)],
                 Some(&mut push_options),
@@ -591,11 +583,6 @@ mod tests {
             .unwrap();
     }
 
-    // Reproduces the production scenario where a concurrent writer advances the
-    // state branch before cepler pushes: cepler must rebase its state commit onto
-    // the new remote tip and push successfully instead of erroring out with a
-    // non-fast-forward. Exercises the full fetch -> rebase -> push machinery that
-    // `push`'s retry loop depends on.
     #[test]
     fn push_rebases_state_commit_onto_concurrent_remote_commit() {
         let base = unique_tmp_dir("push");
@@ -604,7 +591,6 @@ mod tests {
         let work_b = base.join("work_b");
         let bare_url = bare_path.to_str().unwrap().to_string();
 
-        // Bare remote + worker A seeded with an initial commit on the default branch.
         Repository::init_bare(&bare_path).unwrap();
         let repo_a = Repository::init(&work_a).unwrap();
         repo_a.remote("origin", &bare_url).unwrap();
@@ -613,13 +599,11 @@ mod tests {
         let branch = repo_a.head().unwrap().shorthand().unwrap().to_string();
         push_branch(&repo_a, &branch);
 
-        // A second worker advances the remote branch with an unrelated commit.
         let repo_b = Repository::clone(&bare_url, &work_b).unwrap();
         std::fs::write(work_b.join("other.txt"), "concurrent").unwrap();
         let concurrent = stage_and_commit(&repo_b, "concurrent writer commit");
         push_branch(&repo_b, &branch);
 
-        // Worker A (still pointing at the old tip) records new state and pushes.
         std::fs::write(work_a.join("state.txt"), "cepler state").unwrap();
         stage_and_commit(&repo_a, "ci(cepler): Updated state");
 
@@ -638,8 +622,6 @@ mod tests {
         let pushed = repo.push(config).expect("push should succeed after rebase");
         assert!(pushed, "expected the state commit to be pushed");
 
-        // The remote tip must now contain BOTH the concurrent commit and our state,
-        // with the state commit rebased directly on top of the concurrent commit.
         let verify = Repository::clone(&bare_url, base.join("verify")).unwrap();
         let tip = verify.head().unwrap().peel_to_commit().unwrap();
         assert_eq!(tip.summary().unwrap(), "ci(cepler): Updated state");


### PR DESCRIPTION
## Summary

Production rollouts intermittently fail in the cepler state-recording step with:

```
Pushing to remote
Error: Couldn't push to remote
Caused by:
    cannot push because a reference that you are trying to update on the remote
    contains commits that are not present locally.; class=Reference (4); code=NotFastForward (-11)
```

Observed on volcano-qa `volcano-qa-galoy-deps` builds 20, 25, 29 (all the same error; surrounded by passing builds).

### Root cause

`Repo::push` performs **fetch → rebase → push** as a single shot with **no retry**. cepler records its state onto a branch that many other CI jobs (and humans) also write to. If any commit lands on the remote branch in the window between cepler's internal fetch and its push, the push becomes a non-fast-forward, libgit2 rejects it with `ErrorCode::NotFastForward`, and the entire deploy fails. The intermittent pattern (fails, then a plain re-run succeeds) is the signature of this race.

### Fix

- Extract the existing fetch/rebase/push body into `try_push`.
- `push` now wraps it in a bounded retry loop (5 attempts, short linear backoff). On failure it downcasts the error to `git2::Error` and **only retries `NotFastForward`** — every other error class propagates immediately, exactly as before. Each retry re-fetches and re-rebases the state commit onto the new remote tip.
- The push error inside `try_push` is intentionally left unwrapped so the caller can downcast it; the final "Couldn't push to remote" context is re-attached when giving up, so the user-facing error message is unchanged.

**No dependency changes** (git2 0.13 etc. untouched), as requested.

### Test plan

- [x] `cargo test --all-features` — added `push_rebases_state_commit_onto_concurrent_remote_commit`, which sets up a local bare remote, has a second worker advance the branch, then asserts `push` rebases the state commit onto the concurrent commit and succeeds. Passes.
- [x] `cargo clippy --all-targets` — clean for `repo.rs` (the pre-existing `config.rs:145` `cmp_owned` warning is untouched and out of scope).
- [x] `cargo build` / `cargo fmt` clean.
- [ ] Note: the existing `bats` integration suite is unaffected by this change (it does not exercise the `record --push` path). It currently fails when run from a `.claude/worktrees/...` path because the harness's `basename ${BATS_TEST_FILENAME%%.*}` mis-resolves the fixture dir when the path contains a dot — pre-existing and unrelated.

> A fully deterministic regression test for the *in-window* race isn't feasible without mocking libgit2 internals (cepler always re-fetches at the top of `push`, so a working fetch never reproduces the race on the first attempt). The added test covers the surrounding fetch/rebase/push machinery the retry depends on; the retry path itself is guarded by the `NotFastForward` downcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)