### PR TITLE
chore: publish cepler images to GCR

### DIFF
--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -5,9 +5,9 @@ github_owner: bodymindarts
  git_uri: git@github.com:bodymindarts/cepler.git
  git_branch: main
 
- docker_registry: cepler
- docker_registry_user: ((docker-creds.username))
- docker_registry_password: ((docker-creds.password))
+ docker_registry: us.gcr.io/galoyorg
+ docker_registry_user: ((gar-creds.username))
+ docker_registry_password: ((gar-creds.password))
  osxcross_username: ((osxcross-image.username))
  osxcross_password: ((osxcross-image.password))
  osxcross_repository: ((osxcross-image.repository))

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -8,9 +8,9 @@ git_uri: git@github.com:bodymindarts/cepler.git
 git_branch: main
 git_version_branch: version
 
-docker_registry: cepler
-docker_registry_user: ((docker-creds.username))
-docker_registry_password: ((docker-creds.password))
+docker_registry: us.gcr.io/galoyorg
+docker_registry_user: ((gar-creds.username))
+docker_registry_password: ((gar-creds.password))
 osxcross_docker_username: ((osxcross-image.username))
 osxcross_docker_password: ((osxcross-image.password))
 osxcross_repository: ((osxcross-image.repository))


### PR DESCRIPTION
Switch the Cepler self-release pipeline from Docker Hub to `us.gcr.io/galoyorg` for the pipeline and Concourse resource images. The pipeline now uses `gar-creds` instead of `docker-creds` for those pushes.

Validated by rendering with `ytt -f ci/pipeline.yml -f ci/values.yml`, validating with `fly -t galoy validate-pipeline`, repiping the live `cepler/cepler` pipeline, and rerunning:

- `cepler/build-pipeline-image #2` pushed `us.gcr.io/galoyorg/cepler-pipeline:latest` successfully.
- `cepler/build-concourse-resource-edge #2` pushed `us.gcr.io/galoyorg/cepler-concourse-resource:edge` successfully.