### PR TITLE
fix(ci): make ci/repipe runnable + add ytt to dev shell

### DIFF
--- a/ci/repipe
+++ b/ci/repipe
@@ -11,11 +11,10 @@ target="${FLY_TARGET:-cepler}"
 
 REPO_ROOT_DIR="$(dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd ))"
 
-TMPDIR=""¬
 TMPDIR=$(mktemp -d -t repipe.XXXXXX)
 trap "rm -rf ${TMPDIR}" INT TERM QUIT EXIT
 
-ytt -f ci > ${TMPDIR}/pipeline.yml
+ytt -f ci/pipeline.yml -f ci/values.yml > ${TMPDIR}/pipeline.yml
 
 echo "Updating pipeline @ ${target}"
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             cargo-watch
             bats
             jq
+            ytt
           ];
           CC = "${clang_16}/bin/clang";
         };


### PR DESCRIPTION
## Summary

Three small fixes that together make `ci/repipe` work from a clean checkout.

### `flake.nix`
- Add `ytt` to the dev-shell packages so `ci/repipe`'s preflight (`which ytt`) succeeds. Previously the script bailed with `You will need to install ytt to repipe.`

### `ci/repipe`
- Drop the stray `TMPDIR=""¬` line. The trailing `¬` (U+00AC) set `TMPDIR=¬`, which `mktemp -d -t repipe.XXXXXX` then used as the prefix, producing `mktemp: failed to create directory via template '¬/repipe.XXXXXX': No such file or directory`. The next line already assigns `TMPDIR` via `mktemp`, so the broken line is just dead.
- Scope ytt's inputs explicitly: `ytt -f ci/pipeline.yml -f ci/values.yml` instead of `ytt -f ci`. `ytt -f ci` was slurping `ci/settings.yml` too — that file has invalid YAML indentation, no `#@data/values` header, and isn't referenced anywhere else in the repo. The intended data-values file is `ci/values.yml`.

## Test plan

- [x] `nix develop --command which ytt` → `ytt version 0.52.0`.
- [x] `nix develop --command ci/repipe` → renders the pipeline (491 lines) and proceeds to `fly set-pipeline`, failing only at `error: unknown target: cepler` (user-side `fly login` needed; unrelated to the script).
- [x] `alejandra --check flake.nix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)