### PR TITLE
fix: satisfy newer clippy lints

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,10 +34,11 @@ impl Config {
         let all_environments: HashSet<String> = config.environments.keys().cloned().collect();
         for (name, env) in config.environments.iter_mut() {
             env.name = name.clone();
-            if let Some(previous) = env.propagated_from.as_ref() {
-                if !all_environments.contains(previous) {
+            match env.propagated_from.as_ref() {
+                Some(previous) if !all_environments.contains(previous) => {
                     return Err(anyhow!("Previous environment '{}' not defined", previous));
                 }
+                _ => {}
             }
         }
 
@@ -101,15 +102,13 @@ impl EnvironmentConfig {
     pub fn propagated_file_patterns(&self) -> impl Iterator<Item = glob::Pattern> + '_ {
         self.propagated_files
             .iter()
-            .cloned()
-            .map(|path| glob::Pattern::new(&path).expect("Couldn't compile glob pattern"))
+            .map(|path| glob::Pattern::new(path).expect("Couldn't compile glob pattern"))
     }
 
     pub fn head_file_patterns(&self) -> impl Iterator<Item = glob::Pattern> + '_ {
         self.head_files
             .iter()
-            .cloned()
-            .map(|path| glob::Pattern::new(&path).expect("Couldn't compile glob pattern"))
+            .map(|path| glob::Pattern::new(path).expect("Couldn't compile glob pattern"))
     }
 }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -193,10 +193,8 @@ impl Repo {
         let mut n_applied = 0;
         while let Some(_) = rebase.next() {
             let res = rebase.commit(None, &sig, None);
-            if let Err(ref e) = res {
-                if e.code() == git2::ErrorCode::Applied {
-                    continue;
-                }
+            if matches!(&res, Err(e) if e.code() == git2::ErrorCode::Applied) {
+                continue;
             }
             n_applied += 1;
             res.context("Couldn't commit rebase")?;
@@ -299,11 +297,12 @@ impl Repo {
         tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
             let path_name = format!("{}{}", dir, entry.name().expect("Entry has no name"));
             let path = Path::new(&path_name);
-            if let Some(ObjectType::Blob) = entry.kind() {
-                if let Err(e) = f(FileHash(entry.id().to_string()), path) {
-                    ret = Err(e);
-                    return TreeWalkResult::Abort;
-                }
+            if !matches!(entry.kind(), Some(ObjectType::Blob)) {
+                return TreeWalkResult::Ok;
+            }
+            if let Err(e) = f(FileHash(entry.id().to_string()), path) {
+                ret = Err(e);
+                return TreeWalkResult::Abort;
             }
             TreeWalkResult::Ok
         })?;
@@ -506,7 +505,7 @@ impl Repo {
         self.gate_commit().id()
     }
 
-    fn gate_object(&self) -> Object {
+    fn gate_object(&self) -> Object<'_> {
         self.inner
             .find_object(self.gate_oid(), Some(ObjectType::Commit))
             .unwrap()

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -267,10 +267,11 @@ impl Workspace {
                 new_env_state.propagated_head = Some(passed_state.head_commit.clone());
                 for (ident, prev_state) in passed_state.files.iter() {
                     let name = ident.name();
-                    if let Some(last_hash) = prev_state.file_hash.as_ref() {
-                        if patterns
-                            .iter()
-                            .any(|p| p.matches_with(&name, MATCH_OPTIONS))
+                    match prev_state.file_hash.as_ref() {
+                        Some(last_hash)
+                            if patterns
+                                .iter()
+                                .any(|p| p.matches_with(&name, MATCH_OPTIONS)) =>
                         {
                             let (dirty, file_hash) = if recording {
                                 if let Some(file_hash) = hash_file(&name) {
@@ -291,6 +292,7 @@ impl Workspace {
                             inserted_files.insert(name.clone(), ident.clone());
                             new_env_state.files.insert(ident, file_state);
                         }
+                        _ => {}
                     }
                 }
             }


### PR DESCRIPTION
Fix the `test-unit` failure under the current `cepler-pipeline` image, where Rust stable is now 1.96.0 and `fail-on-warnings` turns new clippy warnings into errors.

Validated locally with:

- `nix develop -c cargo fmt --check`
- `nix develop -c make test-in-ci`

Validated in Concourse with one-off build `9345117` using `us.gcr.io/galoyorg/cepler-pipeline`, running `ci/tasks/test-unit.sh` against this branch content; it succeeded.

Note: PR #13 already merged the GCR registry move, so this PR now contains only the clippy/test-unit fix.