### PR TITLE
perf(concourse): skip clone in 'in' when no environment is configured

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,1 +1,1 @@
-Empty - please add release notes here
+- concourse `in`: skip clone when no environment is configured

--- a/src/concourse/ci_in.rs
+++ b/src/concourse/ci_in.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::workspace::Workspace;
 use glob::*;
-use std::{io, path::Path};
+use std::{fs, io, path::Path};
 
 pub fn exec(destination: &str) -> Result<()> {
     eprintln!("Preparing resource - cepler v{}", clap::crate_version!());
@@ -12,8 +12,18 @@ pub fn exec(destination: &str) -> Result<()> {
     }: ResourceConfig<InParams> =
         serde_json::from_reader(io::stdin()).context("Deserializing stdin")?;
     let should_prepare = params.map(|p| p.prepare).unwrap_or(true);
-    eprintln!("Cloning repo to '{}'", destination);
     let version = version.expect("No version specified");
+
+    // Short-circuit when no environment is configured: the cloned repo would
+    // only be deleted by `empty_repo` anyway, so skip the expensive clone.
+    let Some(environment) = source.environment.clone() else {
+        eprintln!("No environment specified... providing an empty dir");
+        fs::create_dir_all(destination)?;
+        std::env::set_current_dir(destination)?;
+        return empty_repo(version);
+    };
+
+    eprintln!("Cloning repo to '{}'", destination);
     let conf = GitConfig {
         url: source.uri,
         branch: source.branch.clone(),
@@ -33,12 +43,6 @@ pub fn exec(destination: &str) -> Result<()> {
 
     let config = Config::from_file(&source.config)?;
     let ws = Workspace::new(&config.scope, source.config, source.ignore_queue)?;
-    let environment = if let Some(environment) = source.environment {
-        environment
-    } else {
-        eprintln!("No environment specified... providing an empty dir");
-        return empty_repo(version);
-    };
     let env = config
         .environments
         .get(&environment)


### PR DESCRIPTION
## Summary

Speeds up the concourse `get` step (cepler's `in` script) by skipping the gates-repo clone when no `environment` is configured. Today the clone happens unconditionally, then the cloned tree is immediately deleted by `empty_repo`. For pipelines like `volcano-qa-cluster-deps`, the implicit `get` Concourse runs after `out` falls into this branch (no environment on the post-deploy task), so every cepler job pays for a full clone just to produce an empty dir.

Move the environment check above the clone. When unset, emit the empty-dir output without touching the network.

## Background

Concrete trace: build [#6 of `volcano-qa-cluster-deps`](https://ci.galoy.io/teams/volcano-qa/pipelines/volcano-qa/jobs/volcano-qa-cluster-deps/builds/6) took 6m20s end-to-end for a no-op terraform apply (only ~36s of real work).

| phase | time |
| --- | ---: |
| `in` clone #1 | 68s |
| ws prepare + worker init | 30s |
| terraform refresh (no-op) | 36s |
| `out` record + push | 28s |
| Concourse re-check gap | 125s |
| **`in` clone #2 → `\"providing an empty dir\"`** | **93s** |
| **Total** | **380s** |

This PR removes clone #2 (~93s).

## What this PR does *not* do

An earlier revision of this PR also added a `$TMPDIR/cepler-repo-cache` reuse path to `ci_in.rs`, mirroring what `check.rs` does. **That was wrong** and has been dropped:

- The Concourse docs are explicit: *\"the container for checking versions is reused between checks, so that it can efficiently pull rather than cloning every time.\"* — i.e. `check` containers persist, so `$TMPDIR` survives across `check` invocations. That's why `check.rs`'s cache works.
- `in` containers are **not** reused across invocations — each `get` runs in a fresh container with a fresh tmpfs. A `$TMPDIR` cache seeded by `in` would never be read.
- Concourse handles cross-invocation `in` caching itself via per-(resource_config, version) cache volumes, so the canonical `concourse/git-resource` `in` script does a plain `git clone` with no userland cache (see [`concourse/git-resource#73`](https://github.com/concourse/git-resource/issues/73)).

So clone #1's 68s is essentially unavoidable from within cepler. Speeding it up further would require either:

- Concourse-side: lower `check_every` on the consumer pipeline (cuts the 125s gap, not in this repo).
- Trimming the gates-repo history (every cepler `out` appends a state commit, so clones grow without bound).
- Shallow clone — doesn't help cepler since `ws.check` needs history.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -D warnings` clean
- [x] `cargo nextest run` — 2/2 pass
- [x] `bats test/integration/` — same pass/fail as `main` (one pre-existing `glob.bats` failure, not caused by this change)
- [ ] Validate against a real Concourse pipeline (e.g. volcano-qa) — recommended before relying on the perf win

🤖 Generated with [Claude Code](https://claude.com/claude-code)