### PR TITLE
fix(concourse): accept SSH host certificate after git2 1.7 upgrade

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,4 +1,1 @@
-- concourse `in`: optional `depth` source param for shallow clones, mirroring the official `git` resource. cuts the first `get` clone for large repos by an order of magnitude when set.
-- shallow clones deepen on-demand when a history walk reaches the shallow boundary, so `find_last_changed_commit` and the state diff still resolve correctly.
-- `out` skips the pre-push fetch on the first attempt — the workspace was freshly cloned by `in` seconds earlier. fetch+rebase only happens on `NotFastForward` retry.
-- bump `git2` 0.13 -> 0.20 (required for shallow-clone support).
+- fix(concourse): SSH host key rejection (`invalid or unknown remote ssh hostkey; class=Ssh (23); code=-17`) introduced by the git2 0.13 → 0.20 bump in v0.7.18. libgit2 1.7+ enforces host key verification by default; restore the pre-bump permissive behaviour by installing a `certificate_check` callback that accepts the remote certificate. Concourse pipelines run against a known git remote and the user's SSH private key already authenticates the connection.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,9 +1,9 @@
 use super::config::{MATCH_OPTIONS, default_scope};
 use anyhow::{Context, Result};
 use git2::{
-    BranchType, Commit, Cred, MergeOptions, Object, ObjectType, Oid, PushOptions, RebaseOptions,
-    RemoteCallbacks, Repository, ResetType, Signature, TreeWalkMode, TreeWalkResult,
-    build::CheckoutBuilder,
+    BranchType, CertificateCheckStatus, Commit, Cred, MergeOptions, Object, ObjectType, Oid,
+    PushOptions, RebaseOptions, RemoteCallbacks, Repository, ResetType, Signature, TreeWalkMode,
+    TreeWalkResult, build::CheckoutBuilder,
 };
 use glob::*;
 use serde::{Deserialize, Serialize};
@@ -652,6 +652,17 @@ fn remote_callbacks(key: String) -> RemoteCallbacks<'static> {
     callbacks.credentials(move |_url, username_from_url, _allowed_types| {
         Cred::ssh_key_from_memory(username_from_url.unwrap(), None, &key, None)
     });
+    // libgit2 1.7+ (pulled in by git2 0.20) rejects unknown SSH host keys
+    // with `invalid or unknown remote ssh hostkey; class=Ssh (23); code=-17`
+    // unless the caller installs a certificate_check callback. The
+    // pre-bump cepler (git2 0.13 / libgit2 1.3.x) silently accepted any
+    // host key — concourse pipelines run against a known git remote and
+    // the user's SSH private key already authenticates the connection,
+    // so restore the prior behaviour by explicitly accepting the host
+    // certificate. Returning `CertificatePassthrough` would defer to
+    // libgit2's built-in check, which without a known_hosts file at a
+    // path libgit2 looks for will hard-reject every host.
+    callbacks.certificate_check(|_cert, _host| Ok(CertificateCheckStatus::CertificateOk));
     callbacks
 }
 


### PR DESCRIPTION
## Problem

v0.7.18 (#18) bumped \`git2\` 0.13 → 0.20, which pulled in libgit2 1.7+. 1.7 enforces strict SSH host-key verification by default and rejects unknown hosts with:

\`\`\`
Error: Couldn't clone repo

Caused by:
    invalid or unknown remote ssh hostkey; class=Ssh (23); code=Certificate (-17)
\`\`\`

Observed on volcano-qa immediately after rolling out the v0.7.18 edge image — every cepler \`check\` and \`in\` failed with this error because libgit2 had no \`known_hosts\` file at any path it probes inside the resource container.

## Fix

The pre-bump git2 0.13 (libgit2 1.3) silently accepted any host key. Concourse pipelines run against a known git remote and the user's SSH private key already authenticates the connection, so restore that behaviour by installing a \`certificate_check\` callback that returns \`CertificateCheckStatus::CertificateOk\` unconditionally.

\`CertificatePassthrough\` is not an option — without a \`known_hosts\` file at a libgit2-recognised path, the built-in check hard-rejects every host, which is exactly what we're seeing.

## Test plan

- [x] \`nix flake check\` passes
- [x] \`cargo nextest run --locked\` — 4/4 pass
- [ ] After merge: rebuild the edge image and confirm volcano-qa's cluster-deps-ungated resource starts producing new versions again

## Affected paths

Every git operation cepler does — \`Repo::clone\`, \`Repo::pull\`, \`Repo::push\`, and \`try_push\`'s fetch — funnels through \`remote_callbacks(private_key)\`, so this single change covers all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)