### PR TITLE
ci(version-resource): switch to file: number to disambiguate

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -425,7 +425,14 @@ resources:
   type: semver
   source:
     driver: git
-    file: version
+    # Was `file: version`, which collides with the branch name (`version`):
+    # semver-resource's getOldVersions calls `git log ... <file>` and
+    # `git show <commit>:<file>` without a `--` separator, so when both a
+    # local branch and a file are named `version` git refuses with
+    # `fatal: ambiguous argument: both revision and filename` (exit 128)
+    # and the resource fails to check. Use `number` to disambiguate —
+    # the file content (a semver string) is unchanged.
+    file: number
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_version_branch
     private_key: #@ data.values.github_private_key


### PR DESCRIPTION
## Why

The \`version\` resource has been failing its check with:

\`\`\`
error checking for new versions: exit status 128
\`\`\`

Reproduced: with a local branch named \`version\` AND a file named \`version\`, semver-resource runs

\`\`\`
git log --pretty=format:%H -n 1 --skip N version
\`\`\`

(no \`--\` separator — see [\`driver/git.go getOldVersions\`](https://github.com/concourse/semver-resource/blob/master/driver/git.go)) and git refuses:

\`\`\`
fatal: ambiguous argument 'version': both revision and filename
$ echo \$?
128
\`\`\`

Started after semver-resource was rebuilt with the new \`--no-checkout --filter=blob:none\` + sparse-checkout flow; the older flow detached HEAD at FETCH_HEAD with no local \`version\` branch, so the bare argument resolved unambiguously to the file path.

## What this PR does

Switch the source param \`file: version\` → \`file: number\`. The file name and the branch name no longer collide, the bare argument resolves to a path, and check succeeds.

## Companion commits on the \`version\` branch

Already pushed:

| commit | message |
|---|---|
| [\`f8314d5\`](https://github.com/bodymindarts/cepler/commit/f8314d5) | chore: add number alongside version to migrate off ambiguous filename |
| [\`616338a\`](https://github.com/bodymindarts/cepler/commit/616338a) | chore: drop now-stale version file (renamed to number) |

Together they effectively \`git mv version number\` on the version branch.

### Why two commits, and is it safe?

Between pushing the rename and the user running \`./ci/repipe\`, the pipeline is still configured with \`file: version\`, so semver-resource will read the missing \`version\` file and return \`InitialVersion = 0.0.0\`. I traced the pipeline to confirm no auto-trigger fires from that:

| job | triggers on \`version\`? |
|---|---|
| \`rc\` | no — triggered by \`repo\` |
| \`release\` | no \`trigger: true\` — gated through \`passed: [rc]\` |
| \`auto-bump-patch\` | \`trigger: true\` on \`version\`, but only with \`passed: [release]\`; \`0.0.0\` cannot have passed \`release\` |
| \`publish\` | same — \`passed: [release]\` |

So during the window, the resource check goes "green with 0.0.0" superficially but nothing fires. After repipe, semver-resource reads \`number\`, sees \`0.7.19-rc.3\`, and concourse picks it back up as the latest.

## Steps to ship

1. Merge this PR.
2. Run \`./ci/repipe\` so concourse picks up \`file: number\`.
3. Verify https://ci.galoy.io/teams/cepler/pipelines/cepler/resources/version goes green at \`0.7.19-rc.3\` (not \`0.0.0\`).

## Upstream

Bug in concourse/semver-resource — \`getOldVersions\` should pass \`--\` before \`<file>\` in both \`git log\` and \`git show\`. Worth filing as follow-up so other projects don't trip on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)