### PR TITLE
perf(concourse): skip implicit checkout on clone, default depth to 50

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,1 +1,2 @@
-Empty - please add release notes here
+- concourse `in`/`check`: skip libgit2's implicit full working-tree checkout during the initial clone. On repos with many files this was the dominant wall-clock cost of the `get` step — silent (libgit2 emits no progress for it) and unrelated to network speed. Only the files cepler actually reads from disk (config + state dir + on-disk gates file) are materialised post-clone; everything else stays unwritten until `prepare`/`reproduce` selectively pulls it in.
+- concourse `in`: `depth` source param now defaults to `50` instead of "full clone" — large enough for the on-demand deepener to almost never fire, small enough that the network/pack phase finishes in seconds. Opt out with `depth: 0`.

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -80,7 +80,7 @@ The `put` operation will commit the state via the command `cepler record -e <env
 | `gates_file` | no | — | path to a gates file |
 | `gates_branch` | no | — | branch the gates file lives on |
 | `ignore_queue` | no | `false` | skip queue ordering |
-| `depth` | no | full clone | **performance**: shallow-clone depth for the `in` step, mirroring the official `git` resource's `depth`. Set to e.g. `50` for large repos to drop the per-`get` clone time by an order of magnitude. Cepler will deepen the clone on-demand if a history walk reaches the shallow boundary, so correctness is preserved. |
+| `depth` | no | `50` | shallow-clone depth for the `in` step, mirroring the official `git` resource's `depth`. The default of 50 is plenty for most state-tracking repos; cepler deepens on-demand if a history walk reaches the shallow boundary, so correctness is preserved at any value. Set to `0` to opt out and do a full clone. |
 
 ## Pipeline generation
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,8 +88,13 @@ pub fn run() -> Result<()> {
         };
         let path = std::path::Path::new(&dir);
         if !path.exists() || path.read_dir()?.next().is_none() {
-            Repo::clone(conf)?;
+            // `Repo::clone` skips the implicit working-tree checkout for
+            // perf — fine for the concourse `in`/`check` paths, but CLI
+            // users expect a fully-materialised workspace to inspect /
+            // operate on. Materialise HEAD explicitly here.
+            let repo = Repo::clone(conf)?;
             std::env::set_current_dir(dir)?;
+            repo.checkout_head()?;
         } else {
             std::env::set_current_dir(dir)?;
             Repo::open(None)?.pull(conf)?;

--- a/src/concourse/check.rs
+++ b/src/concourse/check.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{config::Config, workspace::Workspace};
+use crate::workspace::Workspace;
 use std::{
     env,
     fs::File,
@@ -66,7 +66,15 @@ pub fn exec() -> Result<()> {
         source.branch, hash, summary
     );
 
-    let config = Config::from_file(&source.config)?;
+    // Idempotent on the pull path (where `Repo::pull`'s Hard reset has
+    // already populated the WT) and load-bearing on the no-checkout
+    // clone path (where the WT is still empty).
+    let config = populate_workspace_metadata(
+        &repo,
+        &source.config,
+        source.gates_file.as_ref(),
+        source.gates_branch.as_ref(),
+    )?;
     let ws = Workspace::new(&config.scope, source.config.clone(), source.ignore_queue)?;
     let mut res = Vec::new();
     let environment = if let Some(environment) = source.environment {

--- a/src/concourse/ci_in.rs
+++ b/src/concourse/ci_in.rs
@@ -46,7 +46,14 @@ pub fn exec(destination: &str) -> Result<()> {
         source.branch, hash, summary
     );
 
-    let config = Config::from_file(&source.config)?;
+    // `Repo::clone` skips the implicit full-tree checkout; pull in just
+    // the files cepler reads from disk before continuing.
+    let config = populate_workspace_metadata(
+        &repo,
+        &source.config,
+        source.gates_file.as_ref(),
+        source.gates_branch.as_ref(),
+    )?;
     let fetch_credentials = repo.fetch_credentials().cloned();
     let ws = Workspace::new(&config.scope, source.config, source.ignore_queue)?
         .with_fetch_credentials(fetch_credentials);

--- a/src/concourse/mod.rs
+++ b/src/concourse/mod.rs
@@ -1,4 +1,4 @@
-use crate::{config::*, repo::*, workspace::StateId};
+use crate::{config::*, database::Database, repo::*, workspace::StateId};
 use anyhow::*;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::path::Path;
@@ -27,10 +27,13 @@ struct Source {
     #[serde(default = "default_config_path")]
     config: String,
     /// Shallow-clone depth for the `in` step. Mirrors the concourse
-    /// git-resource's `depth`. `None` or `0` = full clone (current default).
-    /// When set, cepler will deepen on-demand if a history walk crosses the
-    /// shallow boundary.
-    #[serde(default)]
+    /// git-resource's `depth`. Defaults to 50 — large enough that cepler's
+    /// history walks almost always stay within the clone, small enough to
+    /// keep the first `get` fast on big repos. Set to `0` to opt out and
+    /// do a full clone. The on-demand deepening logic still kicks in if a
+    /// walk reaches the shallow boundary, so correctness is preserved
+    /// regardless of the value.
+    #[serde(default = "default_depth")]
     depth: Option<i32>,
 }
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -77,6 +80,51 @@ struct ResourceData {
 
 fn default_config_path() -> String {
     "cepler.yml".to_string()
+}
+
+fn default_depth() -> Option<i32> {
+    Some(50)
+}
+
+/// Materialise the small set of files cepler itself reads from disk
+/// (config + database state directory + optional on-disk gates file)
+/// from a freshly no-checkout-cloned repo. Everything else stays
+/// unwritten — `Workspace::prepare` / `Workspace::reproduce` selectively
+/// checks out env-specific files as a separate step. Returns the parsed
+/// config so the caller doesn't have to round-trip through
+/// `Config::from_file` afterwards.
+fn populate_workspace_metadata(
+    repo: &Repo,
+    path_to_config: &str,
+    gates_file: Option<&String>,
+    gates_branch: Option<&String>,
+) -> Result<Config> {
+    let (head, _) = repo.head_commit_summary()?;
+    let config = repo
+        .get_file_content(head, Path::new(path_to_config), |bytes| {
+            Config::from_reader(bytes)
+        })?
+        .context(format!(
+            "Config file '{}' not found in HEAD",
+            path_to_config
+        ))?;
+
+    let state_dir = Database::state_dir_from_config(&config.scope, path_to_config);
+    let mut paths: Vec<String> = vec![
+        path_to_config.to_string(),
+        // libgit2's checkout pathspec is fnmatch-style — a single `*`
+        // matches everything directly inside the state dir, which is
+        // flat (one `<env>.state` file per environment).
+        format!("{}/*", state_dir),
+    ];
+    // Only the on-disk gates path needs materialising; when `gates_branch`
+    // is set the gates file is read directly from the branch's tree via
+    // `repo.get_file_from_branch`, never from disk.
+    if let (Some(file), None) = (gates_file, gates_branch) {
+        paths.push(file.clone());
+    }
+    repo.checkout_paths(paths)?;
+    Ok(config)
 }
 
 fn get_gate(

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -94,10 +94,37 @@ impl Repo {
             fo.depth(d);
         }
 
+        // Skip libgit2's implicit working-tree checkout. For repos with
+        // many files it dominates clone wall-clock time (~2-3 minutes on
+        // the volcano-qa state repo) and emits no progress, so it looks
+        // like a hang. Callers materialise just the files they actually
+        // need via `checkout_paths` (concourse `in`/`check`) or
+        // `checkout_head` (CLI), which is orders of magnitude faster than
+        // writing every blob in HEAD.
+        let mut no_checkout = git2::build::CheckoutBuilder::new();
+        no_checkout.dry_run();
+
         let mut builder = git2::build::RepoBuilder::new();
         builder.fetch_options(fo);
         builder.branch(&branch);
+        builder.with_checkout(no_checkout);
         let inner = builder.clone(&url, Path::new(&dir))?;
+
+        // libgit2 short-circuits both working-tree AND index population
+        // when checkout_strategy == GIT_CHECKOUT_NONE (see clone.c
+        // `should_checkout`). The index needs to be in sync with HEAD so
+        // that a later `index.write_tree()` from `commit_state_file` on
+        // the `out` step produces a tree that still includes everything
+        // inherited from HEAD — without this step `out` would commit a
+        // tree containing only the new state file, deleting the rest of
+        // the repo. ResetType::Mixed fills the index from HEAD without
+        // touching the working tree.
+        {
+            let head_commit = inner.head()?.peel_to_commit()?;
+            let head_obj = head_commit.into_object();
+            inner.reset(&head_obj, ResetType::Mixed, None)?;
+        }
+
         let fetch_credentials = shallow.map(|_| FetchCredentials {
             branch,
             private_key,
@@ -492,6 +519,39 @@ impl Repo {
         Ok(())
     }
 
+    /// Selectively materialise specific paths from HEAD into the working
+    /// tree. Patterns follow libgit2's fnmatch-style semantics — `*`
+    /// inside a single directory component, no `**` recursion — so a
+    /// state directory is expressed as `dir/*` (the state files are flat
+    /// under it). Used by the concourse `in`/`check` flows after a
+    /// no-checkout clone to populate just the files cepler reads from
+    /// disk (config + state dir + optional gates file).
+    ///
+    /// The index is left untouched (`update_index(false)`) since
+    /// `Repo::clone` already populated it in full via the Mixed reset —
+    /// a partial WT checkout shouldn't be allowed to shrink that record.
+    pub fn checkout_paths<I, S>(&self, paths: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut checkout = CheckoutBuilder::new();
+        checkout.force();
+        checkout.update_index(false);
+        let mut any = false;
+        for path in paths {
+            checkout.path(path.as_ref());
+            any = true;
+        }
+        if !any {
+            return Ok(());
+        }
+        let head_commit = self.inner.head()?.peel_to_commit()?;
+        let head_obj = head_commit.into_object();
+        self.inner.checkout_tree(&head_obj, Some(&mut checkout))?;
+        Ok(())
+    }
+
     pub fn walk_commits_before<F>(&self, commit: CommitHash, mut cb: F) -> Result<()>
     where
         F: FnMut(CommitHash) -> Result<bool>,
@@ -877,6 +937,144 @@ mod tests {
         assert!(
             !msg.contains("Couldn't fetch origin"),
             "first attempt must skip pre-push fetch, got: {msg}"
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn clone_skips_working_tree_checkout_but_populates_index() {
+        // The whole point of switching `Repo::clone` to a no-checkout
+        // clone is that the working tree stays empty (zero per-file
+        // syscalls during clone for repos with thousands of files) while
+        // the index stays fully in sync with HEAD — otherwise the next
+        // `commit_state_file` would build a tree containing only the
+        // newly-added state file, deleting everything else inherited
+        // from HEAD.
+        let base = unique_tmp_dir("clone-no-checkout");
+        let bare_path = base.join("remote.git");
+        let seed_path = base.join("seed");
+        let dest_path = base.join("dest");
+        let bare_url = bare_path.to_str().unwrap().to_string();
+
+        // Build a remote with a few tracked files in HEAD.
+        Repository::init_bare(&bare_path).unwrap();
+        let seed = Repository::init(&seed_path).unwrap();
+        seed.remote("origin", &bare_url).unwrap();
+        std::fs::write(seed_path.join("a.txt"), "alpha").unwrap();
+        std::fs::write(seed_path.join("b.txt"), "beta").unwrap();
+        std::fs::create_dir_all(seed_path.join("nested")).unwrap();
+        std::fs::write(seed_path.join("nested/c.txt"), "gamma").unwrap();
+        stage_and_commit(&seed, "seed commit");
+        let branch = seed.head().unwrap().shorthand().unwrap().to_string();
+        push_branch(&seed, &branch);
+
+        let conf = GitConfig {
+            url: bare_url.clone(),
+            branch: branch.clone(),
+            gates_branch: None,
+            private_key: String::new(),
+            dir: dest_path.to_str().unwrap().to_string(),
+            depth: None,
+        };
+        let repo = Repo::clone(conf).expect("clone should succeed");
+
+        // Working tree is empty — the only entry under `dest/` should be
+        // the `.git` directory.
+        let mut wd_entries: Vec<String> = std::fs::read_dir(&dest_path)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        wd_entries.sort();
+        assert_eq!(
+            wd_entries,
+            vec![".git".to_string()],
+            "no-checkout clone must leave the working tree empty"
+        );
+
+        // Index is fully populated — every blob from HEAD's tree should
+        // be in the index so a downstream `write_tree()` would still
+        // produce the HEAD tree (plus any additions).
+        let mut index = repo.inner.index().unwrap();
+        let entry_paths: std::collections::BTreeSet<String> = (0..index.len())
+            .map(|i| String::from_utf8(index.get(i).unwrap().path).expect("utf8 index path"))
+            .collect();
+        let expected: std::collections::BTreeSet<String> = ["a.txt", "b.txt", "nested/c.txt"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(
+            entry_paths, expected,
+            "index must include every HEAD entry after the Mixed-reset",
+        );
+
+        // `write_tree` from the just-cloned index should reproduce HEAD's
+        // tree exactly — this is what makes `commit_state_file` safe.
+        let written = index.write_tree_to(&repo.inner).unwrap();
+        let head_tree = repo
+            .inner
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .tree()
+            .unwrap()
+            .id();
+        assert_eq!(
+            written, head_tree,
+            "index.write_tree() must reproduce HEAD tree post-clone",
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn checkout_paths_materialises_only_requested_files() {
+        // The concourse `in`/`check` flows pair a no-checkout clone with
+        // a targeted `checkout_paths` for just the files cepler reads
+        // from disk. Verify that the helper writes exactly those paths
+        // (single files + glob patterns) and nothing else.
+        let base = unique_tmp_dir("checkout-paths");
+        let bare_path = base.join("remote.git");
+        let seed_path = base.join("seed");
+        let dest_path = base.join("dest");
+        let bare_url = bare_path.to_str().unwrap().to_string();
+
+        Repository::init_bare(&bare_path).unwrap();
+        let seed = Repository::init(&seed_path).unwrap();
+        seed.remote("origin", &bare_url).unwrap();
+        std::fs::write(seed_path.join("cepler.yml"), "deployment: demo").unwrap();
+        std::fs::create_dir_all(seed_path.join(".cepler/demo")).unwrap();
+        std::fs::write(seed_path.join(".cepler/demo/staging.state"), "v1").unwrap();
+        std::fs::write(seed_path.join(".cepler/demo/prod.state"), "v2").unwrap();
+        std::fs::write(seed_path.join("other.txt"), "should stay unchecked-out").unwrap();
+        stage_and_commit(&seed, "seed");
+        let branch = seed.head().unwrap().shorthand().unwrap().to_string();
+        push_branch(&seed, &branch);
+
+        let conf = GitConfig {
+            url: bare_url.clone(),
+            branch: branch.clone(),
+            gates_branch: None,
+            private_key: String::new(),
+            dir: dest_path.to_str().unwrap().to_string(),
+            depth: None,
+        };
+        let repo = Repo::clone(conf).expect("clone");
+
+        repo.checkout_paths(["cepler.yml", ".cepler/demo/*"])
+            .expect("checkout_paths");
+
+        let on_disk = |p: &str| dest_path.join(p).is_file();
+        assert!(on_disk("cepler.yml"), "config must be materialised");
+        assert!(
+            on_disk(".cepler/demo/staging.state"),
+            "state files matching the glob must be materialised"
+        );
+        assert!(on_disk(".cepler/demo/prod.state"));
+        assert!(
+            !on_disk("other.txt"),
+            "files not matching any requested path must stay unchecked-out"
         );
 
         std::fs::remove_dir_all(&base).ok();


### PR DESCRIPTION
## Summary

Follow-up to #18. The PR added a `depth` source param for shallow clones but the volcano-qa-lana-bank `in` step is still spending ~2m 44s in `Repo::clone` ([build #101](https://ci.galoy.io/teams/volcano-qa/pipelines/volcano-qa/jobs/volcano-qa-lana-bank/builds/101)). After the libgit2 sideband progress finishes (~12s for the network + pack phase), there's ~2m 30s of **silent** wall-clock — that's libgit2 writing every blob in HEAD to the working tree. `Workspace::prepare` / `reproduce` then deletes most of those files and selectively re-checks out only the env-specific subset, so the implicit full-tree checkout is pure waste.

Two changes here:

1. **Skip the implicit checkout on `Repo::clone`** by passing `CheckoutBuilder::new().dry_run()` (= `GIT_CHECKOUT_NONE`) to `RepoBuilder`. libgit2's `clone.c` `should_checkout` short-circuits the entire checkout step. A follow-up `reset(HEAD, Mixed)` populates the index — the NONE strategy also skips that, and without an index in sync with HEAD a later `commit_state_file` on `out` would build a tree containing only the new state file, **deleting everything else inherited from HEAD**.

2. **Default `depth` to `Some(50)`**, matching the rollout plan in #18 that never made it into the volcano-qa pipeline.yml. Users opt out with `depth: 0`.

A new `Repo::checkout_paths` helper does fnmatch-style selective checkout from HEAD. The concourse `in` / `check` flows call it via a shared `populate_workspace_metadata` to materialise just the files cepler reads from disk:
- the config file
- the database state dir (`<config-dir>/.cepler/<scope>/*.state`)
- the on-disk gates file when `gates_branch` isn't set

CLI's `--clone-dir` flow expects a fully-materialised workspace to inspect / operate on, so it calls `repo.checkout_head()` explicitly after `Repo::clone`.

## Test plan

- [x] `nix flake check` — passes
- [x] `cargo nextest run` — 6/6 pass
  - Two new unit tests:
    - `clone_skips_working_tree_checkout_but_populates_index` — proves the working tree stays empty post-clone and that the index still reproduces HEAD's tree via `write_tree`, the safety property `commit_state_file` depends on.
    - `checkout_paths_materialises_only_requested_files` — covers both the single-file and `dir/*` glob shapes used in `populate_workspace_metadata`.
- [ ] Pipeline-level: re-pipe volcano-qa (no source-config change needed — depth defaults kick in automatically) and confirm the `in` step's clone phase drops from ~2m 44s to single-digit seconds.

## Expected impact (volcano-qa-lana-bank)

Build [#101](https://ci.galoy.io/teams/volcano-qa/pipelines/volcano-qa/jobs/volcano-qa-lana-bank/builds/101) on v0.7.18: ~2m 44s from `Cloning repo to '/tmp/build/get'` to `HEAD of branch 'main' is now at: ...`.

With this PR:
- ~10s → ~3s (network/pack phase, thanks to default `depth: 50`)
- ~2m 30s → ~0s (no full working-tree checkout)
- the selective `populate_workspace_metadata` checkout adds a few hundred ms for the config + state files

Net: ~3-5s end-to-end, vs. ~164s today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)