### PR TITLE
perf(concourse): add timing logs to the `in` step

### DIFF
--- a/src/concourse/ci_in.rs
+++ b/src/concourse/ci_in.rs
@@ -67,14 +67,25 @@ pub fn exec(destination: &str) -> Result<()> {
     )?;
 
     let (state_id, diff) = if should_prepare {
-        match ws.check(env, gate.clone())? {
+        let t = std::time::Instant::now();
+        let check_result = ws.check(env, gate.clone())?;
+        eprintln!(
+            "[cepler-perf] ws.check (construct_env_state walk): {:.2}s",
+            t.elapsed().as_secs_f64()
+        );
+        match check_result {
             Some((state_id, _)) if &state_id.head_commit != wanted_trigger => {
                 eprintln!("Trigger is out of sync.");
                 std::process::exit(1);
             }
             None => {
                 eprintln!("Nothing new to deploy... reproducing last state");
+                let t = std::time::Instant::now();
                 let state_id = ws.reproduce(env, true)?;
+                eprintln!(
+                    "[cepler-perf] ws.reproduce: {:.2}s",
+                    t.elapsed().as_secs_f64()
+                );
                 if &state_id.head_commit != wanted_trigger {
                     eprintln!("Reproduced state is out of sync - providing empty dir");
                     return empty_repo(version);
@@ -83,13 +94,23 @@ pub fn exec(destination: &str) -> Result<()> {
             }
             Some(ret) => {
                 eprintln!("Preparing the workspace");
+                let t = std::time::Instant::now();
                 ws.prepare(env, gate, true)?;
+                eprintln!(
+                    "[cepler-perf] ws.prepare (construct_env_state + propagated checkouts): {:.2}s",
+                    t.elapsed().as_secs_f64()
+                );
                 ret
             }
         }
     } else {
         eprintln!("Reproducing last state");
+        let t = std::time::Instant::now();
         let state_id = ws.reproduce(env, true)?;
+        eprintln!(
+            "[cepler-perf] ws.reproduce: {:.2}s",
+            t.elapsed().as_secs_f64()
+        );
         if &state_id.head_commit != wanted_trigger {
             eprintln!("Reproduced state is out of sync - providing empty dir");
             return empty_repo(version);

--- a/src/concourse/mod.rs
+++ b/src/concourse/mod.rs
@@ -87,6 +87,8 @@ fn populate_workspace_metadata(
     gates_branch: Option<&String>,
 ) -> Result<Config> {
     let (head, _) = repo.head_commit_summary()?;
+
+    let t = std::time::Instant::now();
     let config = repo
         .get_file_content(head, Path::new(path_to_config), |bytes| {
             Config::from_reader(bytes)
@@ -95,6 +97,10 @@ fn populate_workspace_metadata(
             "Config file '{}' not found in HEAD",
             path_to_config
         ))?;
+    eprintln!(
+        "[cepler-perf] read config from HEAD tree: {:.2}s",
+        t.elapsed().as_secs_f64()
+    );
 
     let state_dir = Database::state_dir_from_config(&config.scope, path_to_config);
     let mut paths: Vec<String> = vec![
@@ -110,7 +116,12 @@ fn populate_workspace_metadata(
     if let (Some(file), None) = (gates_file, gates_branch) {
         paths.push(file.clone());
     }
+    let t = std::time::Instant::now();
     repo.checkout_paths(paths)?;
+    eprintln!(
+        "[cepler-perf] selective checkout (config + state dir): {:.2}s",
+        t.elapsed().as_secs_f64()
+    );
     Ok(config)
 }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -88,7 +88,13 @@ impl Repo {
         builder.fetch_options(fo);
         builder.branch(&branch);
         builder.with_checkout(no_checkout);
+
+        let t = std::time::Instant::now();
         let inner = builder.clone(&url, Path::new(&dir))?;
+        eprintln!(
+            "[cepler-perf] RepoBuilder::clone (fetch + pack index): {:.2}s",
+            t.elapsed().as_secs_f64()
+        );
 
         // libgit2 short-circuits both working-tree AND index population
         // when checkout_strategy == GIT_CHECKOUT_NONE (see clone.c
@@ -99,11 +105,16 @@ impl Repo {
         // tree containing only the new state file, deleting the rest of
         // the repo. ResetType::Mixed fills the index from HEAD without
         // touching the working tree.
+        let t = std::time::Instant::now();
         {
             let head_commit = inner.head()?.peel_to_commit()?;
             let head_obj = head_commit.into_object();
             inner.reset(&head_obj, ResetType::Mixed, None)?;
         }
+        eprintln!(
+            "[cepler-perf] index sync (Mixed reset from HEAD): {:.2}s",
+            t.elapsed().as_secs_f64()
+        );
 
         Ok(Self { inner, gate: None })
     }


### PR DESCRIPTION
## Summary

A real side-by-side comparison of build [#107](https://ci.galoy.io/teams/volcano-qa/pipelines/volcano-qa/jobs/volcano-qa-lana-bank/builds/107) (cepler v0.7.18) and build [#108](https://ci.galoy.io/teams/volcano-qa/pipelines/volcano-qa/jobs/volcano-qa-lana-bank/builds/108) (v0.7.20 / #24) showed the no-checkout-clone work didn't actually move the wall clock — both spent ~65-68 s between `Cloning repo to '/tmp/build/get'` and `HEAD of branch is now at`.

Two competing hypotheses for why:
- The earlier ~2m 30s "silent gap" we attributed to the implicit checkout was actually slow-worker-disk variance; faster workers always chewed through it in ~50 s.
- `ResetType::Mixed` walks the same HEAD tree the implicit checkout did, so we traded "write 14 MB of blobs" for "write index entries + per-entry stat work" with similar total cost.

The current logs don't disambiguate, so picking the next optimisation is back to guessing. This PR instruments the five-or-so phases of `in` with `[cepler-perf]`-prefixed `eprintln!`s so the next build attributes the time concretely.

## What's instrumented

| Phase | Lives in |
|---|---|
| `RepoBuilder::clone` — fetch + pack index | `Repo::clone` |
| Mixed reset from HEAD (populates the index) | `Repo::clone` |
| `get_file_content` reading cepler.yml from HEAD tree | `populate_workspace_metadata` |
| Selective checkout of config + state dir + on-disk gates | `populate_workspace_metadata` |
| `ws.check` — `construct_env_state` walk | `ci_in.rs` |
| `ws.prepare` — second walk + propagated checkouts | `ci_in.rs` |
| `ws.reproduce` (no-deploy path) | `ci_in.rs` |

Sample output (from a future build):

```
[cepler-perf] RepoBuilder::clone (fetch + pack index): 12.34s
[cepler-perf] index sync (Mixed reset from HEAD): 48.12s
[cepler-perf] read config from HEAD tree: 0.01s
[cepler-perf] selective checkout (config + state dir): 0.34s
[cepler-perf] ws.check (construct_env_state walk): 2.10s
[cepler-perf] ws.prepare (construct_env_state + propagated checkouts): 1.87s
```

(Numbers fabricated; the next build will tell us where the time actually goes.)

## Notes

- Logged unconditionally on every `in` invocation. Each log line is tiny and one-shot per phase, so the noise is negligible. If it gets annoying later, we can gate behind `CEPLER_PERF=1` or similar.
- Targeted only at `in` (the most-frequently-run step and the one the user explicitly asked about). `check` and `out` could get the same treatment in a follow-up if their numbers turn out to matter.
- No behaviour change. All 5 unit tests still pass; `nix flake check` green.

## Test plan

- [x] `cargo nextest run` — 5/5 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `nix flake check` — passes
- [x] `cargo build --release` + `cepler --version` — `cepler 0.7.21-dev`
- [ ] Roll the new image into the volcano-qa pipeline, run the lana-bank job, capture the `[cepler-perf]` lines, and use them to pick the next optimisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)